### PR TITLE
Make install script easier to run

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -30,18 +30,25 @@ Clone the repository. Then, from the project's `src/` directory, execute `make`.
 For the extension to communicate with your system's `pass` script, you need to install what's called the host application.
 
 #### Official release
-Download the `install_host_app.sh` script from [our releases page](https://github.com/nwallace/passff/releases) and execute it.
+Download the `install_host_app.sh` script from [our releases page](https://github.com/nwallace/passff/releases) and execute it. You can do this in one line like so:
+
+```
+$ curl -sSL https://github.com/nwallace/passff/<VERSION>/install_host_app.sh | bash -s -- [firefox|chrome|opera|chromium|vivaldi]
+```
+
+This script will download the host application (a small python script) and the add-on's manifest file (a JSON config file) and put them in the right place.
+If you're concerned about executing a script that downloads files from the web, you can download the files yourself and run the script with the `--local` option instead or link the files yourself. Details below.
 
 #### Latest from GitHub
-Clone the repository. Then, from the project's `host/` directory, execute the installation script for your desired browser (`--firefox`, `--chrome`, `--opera`). Omit the browser flag to install it for any browser you have on your system.
+Clone the repository. Then, from the project's `host/` directory, execute the installation script for your desired browser (`firefox`, `chrome`, `opera`, `chromium`, or `vivaldi`).
 
-  ```
-  $ ./install_host_app.sh --firefox
-  ```
+```
+$ ./install_host_app.sh --local [firefox|chrome|opera|chromium|vivaldi]
+```
 
-This will link the host application JSON file appropriately for your browser.
+This will copy the host application and manifest files to the right place for your browser. The `--local` option makes the script use the files on disk rather than downloading them from GitHub.
 
-If this doesn't work, you can link the file yourself. First, change the "path" value in the `passff.json` file to be the absolute path to the project's `host/passff.py` file. Then symlink (or copy) the file `host/passff.json` to the appropriate location for your browser and OS:
+If this doesn't work, you can link the files yourself. First, change the "path" value in the `passff.json` file to be the absolute path to the project's `host/passff.py` file. Then symlink (or copy) the file `host/passff.json` to the appropriate location for your browser and OS:
 
 - Firefox
   - Linux
@@ -71,3 +78,10 @@ If this doesn't work, you can link the file yourself. First, change the "path" v
     - System-wide: `/Library/Application Support/Chromium/NativeMessagingHosts/passff.json`
 - Opera
   - Same as Chrome
+- Vivaldi
+  - Linux
+    - Per-user: `~/.config/vivaldi/NativeMessagingHosts/passff.json`
+    - System-wide: `/etc/vivaldi/native-messaging-hosts/passff.json`
+  - OS X
+    - Per-user: `~/Library/Application Support/Vivaldi/NativeMessagingHosts/passff.json`
+    - System-wide: `/Library/Application Support/Vivaldi/NativeMessagingHosts/passff.json`

--- a/src/host/install_host_app.sh
+++ b/src/host/install_host_app.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-DIR="$( cd "$( dirname "$0" )" && pwd )"
 APP_NAME="passff"
-HOST_FILE="$DIR/passff.py"
+HOST_URL="https://raw.githubusercontent.com/nwallace/passff/master/src/host/passff.py"
+MANIFEST_URL="https://raw.githubusercontent.com/nwallace/passff/master/src/host/passff.json"
 
 # Find target dirs for various browsers & OS'es
 # https://developer.chrome.com/extensions/nativeMessaging#native-messaging-host-location
@@ -38,8 +38,6 @@ else
   fi
 fi
 
-ESCAPED_HOST_FILE=${HOST_FILE////\\/}
-
 case $1 in
 --chrome)
   BROWSER_NAME="Chrome"
@@ -67,19 +65,24 @@ case $1 in
     ;;
 esac
 
+HOST_FILE_PATH="$TARGET_DIR/$APP_NAME.py"
+MANIFEST_FILE_PATH="$TARGET_DIR/$APP_NAME.json"
+ESCAPED_HOST_FILE_PATH="${HOST_FILE_PATH////\\/}"
+
 echo "Installing $BROWSER_NAME host config"
 
 # Create config dir if not existing
 mkdir -p "$TARGET_DIR"
 
-# Copy manifest host config file
-cp "$DIR/passff.json" "$TARGET_DIR/$APP_NAME.json"
+# Download native host script and manifest
+curl -s "$HOST_URL"     > "$HOST_FILE_PATH"
+curl -s "$MANIFEST_URL" > "$MANIFEST_FILE_PATH"
 
 # Replace path to host
-sed -i -e "s/PLACEHOLDER/$ESCAPED_HOST_FILE/" "$TARGET_DIR/$APP_NAME.json"
+sed -i -e "s/PLACEHOLDER/$ESCAPED_HOST_FILE_PATH/" "$MANIFEST_FILE_PATH"
 
 # Set permissions for the manifest so that all users can read it.
-chmod o+r "$TARGET_DIR/$APP_NAME.json"
-	
-echo "Native messaging host for $BROWSER_NAME has been installed to $TARGET_DIR."
+chmod a+x "$HOST_FILE_PATH"
+chmod o+r "$MANIFEST_FILE_PATH"
 
+echo "Native messaging host for $BROWSER_NAME has been installed to $TARGET_DIR."

--- a/src/host/install_host_app.sh
+++ b/src/host/install_host_app.sh
@@ -29,7 +29,7 @@ else
     TARGET_DIR_CHROME="/etc/opt/chrome/native-messaging-hosts"
     TARGET_DIR_CHROMIUM="/etc/chromium/native-messaging-hosts"
     TARGET_DIR_FIREFOX="/usr/lib/mozilla/native-messaging-hosts"
-    TARGET_DIR_VIVALDI="/etc/chromium/native-messaging-hosts"
+    TARGET_DIR_VIVALDI="/etc/vivaldi/native-messaging-hosts"
   else
     TARGET_DIR_CHROME="$HOME/.config/google-chrome/NativeMessagingHosts"
     TARGET_DIR_CHROMIUM="$HOME/.config/chromium/NativeMessagingHosts"
@@ -38,32 +38,55 @@ else
   fi
 fi
 
-case $1 in
---chrome)
-  BROWSER_NAME="Chrome"
-  TARGET_DIR="$TARGET_DIR_CHROME"
-  ;;
---chromium)
-  BROWSER_NAME="Chromium"
-  TARGET_DIR="$TARGET_DIR_CHROMIUM"
-  ;;
---firefox)
-  BROWSER_NAME="Firefox"
-  TARGET_DIR="$TARGET_DIR_FIREFOX"
-  ;;
---opera)
-  BROWSER_NAME="Opera"
-  TARGET_DIR="$TARGET_DIR_VIVALDI"
-  ;;
---vivaldi)
-  BROWSER_NAME="Vivaldi"
-  TARGET_DIR="$TARGET_DIR_VIVALDI"
-  ;;
-*)
-    echo "Usage: $0 [--chrome|--chromium|--firefox|--opera|--vivaldi]"
-    exit 1
-    ;;
-esac
+function usage {
+  echo "Usage: $0 [OPTION] [chrome|chromium|firefox|opera|vivaldi]
+
+  Options:
+    -l, --local    Install files from disk instead of downloading them
+    -h, --help     Show this message"
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    chrome)
+      BROWSER_NAME="Chrome"
+      TARGET_DIR="$TARGET_DIR_CHROME"
+      ;;
+    chromium)
+      BROWSER_NAME="Chromium"
+      TARGET_DIR="$TARGET_DIR_CHROMIUM"
+      ;;
+    firefox)
+      BROWSER_NAME="Firefox"
+      TARGET_DIR="$TARGET_DIR_FIREFOX"
+      ;;
+    opera)
+      BROWSER_NAME="Opera"
+      TARGET_DIR="$TARGET_DIR_VIVALDI"
+      ;;
+    vivaldi)
+      BROWSER_NAME="Vivaldi"
+      TARGET_DIR="$TARGET_DIR_VIVALDI"
+      ;;
+    -l|--local)
+      USE_LOCAL_FILES=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$TARGET_DIR" ]; then
+  usage
+  exit 1
+fi
 
 HOST_FILE_PATH="$TARGET_DIR/$APP_NAME.py"
 MANIFEST_FILE_PATH="$TARGET_DIR/$APP_NAME.json"
@@ -74,9 +97,15 @@ echo "Installing $BROWSER_NAME host config"
 # Create config dir if not existing
 mkdir -p "$TARGET_DIR"
 
-# Download native host script and manifest
-curl -s "$HOST_URL"     > "$HOST_FILE_PATH"
-curl -s "$MANIFEST_URL" > "$MANIFEST_FILE_PATH"
+if [ "$USE_LOCAL_FILES" = true ]; then
+  DIR="$( cd "$( dirname "$0" )" && pwd )"
+  cp "$DIR/passff.py"   "$HOST_FILE_PATH"
+  cp "$DIR/passff.json" "$MANIFEST_FILE_PATH"
+else
+  # Download native host script and manifest
+  curl -sSL "$HOST_URL"     > "$HOST_FILE_PATH"
+  curl -sSL "$MANIFEST_URL" > "$MANIFEST_FILE_PATH"
+fi
 
 # Replace path to host
 sed -i -e "s/PLACEHOLDER/$ESCAPED_HOST_FILE_PATH/" "$MANIFEST_FILE_PATH"


### PR DESCRIPTION
This commit changes the host app install script to download the host app and manifest files from GitHub instead of using files on disk.

As discussed in #169 , I feel like the install script should be very easy to run. This change enables a user to do one-liners like this to install the host app:

```
$ curl -sSL https://github.com/nwallace/passff/releases/download/1.0/install_host_app.sh | bash -s -- firefox
```

Note: Currently the script downloads the files from the master branch on GitHub. Before a release, we should update this to refer to a tag or release file in GitHub instead.